### PR TITLE
Add tolerance window to TOTP.verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ TOTP
     } else {
         console.log('access denied!');
     }
+
+    // Verify a user supplied password at a given time within a tolerance window.
+    // By default, `window` is 6, which means 6 intervals of tolerance.
+    if(totp.verify(1234567, timeInSeconds, window)) {
+        console.log('access granted!');
+    } else {
+        console.log('access denied!');
+    }
     
 OTP digit size and time interval can be specified as such:
 

--- a/lib/onceler/totp.js
+++ b/lib/onceler/totp.js
@@ -43,8 +43,13 @@ function at(x) {
     return OTP.prototype.at.call(this, this.timeCode(x));
 }
 
-function verify(x) {
-    return this.now() == x;
+function verify(x, now, window) {
+    now = now || Math.floor(new Date().getTime() / 1000);
+    window = window || 6;
+    for (var i = -window; i <= window; i++)
+        if (this.at(now + i * this.interval) == x)
+            return true;
+    return false;
 }
 
 TOTP.prototype.at = at;

--- a/spec/totp_spec.js
+++ b/spec/totp_spec.js
@@ -38,6 +38,16 @@ describe('TOTP', function() {
         var x = totp.now();
 	expect(totp.verify(x)).toBeTruthy();
     });
+
+    it('should verify with a window of allowed values', function() {
+    var totp = new TOTP('IFAUCQKCIJBEE===');
+    var now = 1428054585; // Test time (in seconds)
+    expect(totp.verify(331409, now)).toBeTruthy(); // Two values in the past
+    expect(totp.verify(101970, now)).toBeTruthy(); // One value in the past
+    expect(totp.verify(445404, now)).toBeTruthy(); // Exact value for test time
+    expect(totp.verify(424176, now)).toBeTruthy(); // One value in the future
+    expect(totp.verify(934182, now)).toBeTruthy(); // Two values in the future
+    });
     
     it('should get value at an index of a specified digit size', function() {
 	var totp = new TOTP('IFAUCQKCIJBEE===', 8);


### PR DESCRIPTION
This patch adds support for a tolerance window while verifying a TOTP, to take into account time skew between the server and the client.
By default, the window is set to 6 intervals, which translates into 3 minutes of time.
